### PR TITLE
Bugfix patch apply

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -572,12 +572,24 @@ class Runner:
         if not subproject_source_dir.is_dir():
             return True
 
+
+        # Remove subproject's source directory
         try:
             if options.confirm:
                 windows_proof_rmtree(str(subproject_source_dir))
             self.log(f'Deleting {subproject_source_dir}')
         except OSError as e:
             mlog.error(f'Unable to remove: {subproject_source_dir}: {e}')
+            return False
+
+        # Remove subproject's patch extract directory
+        subproject_patch_dir = f'{str(subproject_source_dir)}.patch.dir'
+        try:
+            if options.confirm:
+                windows_proof_rmtree(subproject_patch_dir)
+            self.log(f'Deleting {subproject_patch_dir}')
+        except OSError as e:
+            mlog.error(f'Unable to remove: {subproject_patch_dir}: {e}')
             return False
 
         return True

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -821,6 +821,7 @@ class Resolver:
         return [str(file.absolute()) for file in directory_path.rglob('*') if file.is_file()]
 
     def apply_patch_file(self, patch_file_abs_path : str) -> None:
+        mlog.log('Applying patch file:', mlog.bold(os.path.relpath(patch_file_abs_path, self.subdir_root)), 'to', mlog.bold(self.wrap.name))
         relpath = os.path.relpath(patch_file_abs_path, self.dirname)
         if PATCH:
             # Always pass a POSIX path to patch, because on Windows it's MSYS


### PR DESCRIPTION
## Fully support applying a patch archive to a subproject after git-cloning
As per my understanding, meson was only downloading and extracting the patch archive, but wasn't applying it to the subproject after cloning. So, I've implemented the patching and also made some minor changes, for example, the patch archive will be extracted into a separate directory named `{package_name/wrap_name}.patch.dir`. It will also be deleted when executing `meson subprojects purge --confirm`.
### Example of a [wrap-git] wrap which also applies a patch
```yaml
[wrap-git]
url = https://github.com/DaanDeMeyer/reproc.git
revision = HEAD
depth = 1
method = cmake
patch_url=https://raw.githubusercontent.com/ravi688/patch-archives/refs/heads/main/reproc-enable-pic.tar
patch_filename=reproc-enable-pic.tar
patch_hash=5eb5f757e24bc140d0ff55c1d33a8124a58e5b580bb09453d894d359ede0506e

[provide]
reproc = reproc_dep
```